### PR TITLE
Tensorlake Tool Integration

### DIFF
--- a/examples/signature_detection_agent.py
+++ b/examples/signature_detection_agent.py
@@ -1,0 +1,176 @@
+import asyncio
+import os
+from typing import Annotated, TypedDict, Union, List
+from langchain_core.messages import HumanMessage
+from langgraph.graph import StateGraph, END
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode
+from langchain_openai import ChatOpenAI
+from tensorlake.documentai.parse import ChunkingStrategy, TableOutputMode
+
+from ..src.tensorlake_tool import DocumentParserOptions, document_markdown_tool
+
+# Set API keys
+os.environ["TENSORLAKE_API_KEY"] = "your_tensorlake_api_key_here"
+os.environ["OPENAI_API_KEY"] = "your_openai_api_key_here"
+
+
+# Define the agent state
+class AgentState(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+# Agent node - decides whether to use tools
+async def agent_node(state: AgentState):
+    model = ChatOpenAI(
+        model="gpt-4o",
+        temperature=0.1
+    ).bind_tools([document_markdown_tool])
+
+    response = await model.ainvoke(state["messages"])
+    return {"messages": [response]}
+
+
+# Conditional Logic for Tool Use
+def should_continue(state: AgentState):
+    last_message = state["messages"][-1]
+    if hasattr(last_message, 'tool_calls') and last_message.tool_calls:
+        return "tools"
+    return END
+
+
+# LangGraph Workflow Setup
+workflow = StateGraph(AgentState)
+workflow.add_node("agent", agent_node)
+workflow.add_node("tools", ToolNode([document_markdown_tool]))
+workflow.set_entry_point("agent")
+workflow.add_conditional_edges("agent", should_continue, {"tools": "tools", END: END})
+workflow.add_edge("tools", "agent")
+app = workflow.compile()
+
+
+# Prompt builder
+def build_document_analysis_prompt(parsed_result: str, questions: Union[str, List[str]]) -> str:
+    # Normalize single question to list
+    if isinstance(questions, str):
+        questions = [questions]
+
+    question_block = "\n".join(f"{i + 1}. {q}" for i, q in enumerate(questions))
+
+    return f"""You are an expert document analyzer.
+I've processed a document and got this result:
+
+{parsed_result}
+
+Please analyze this output and answer the following:
+{question_block}
+"""
+
+
+# # Document + Agent Pipeline
+async def analyze_signatures_agents(
+        file_path: str,
+        parsing_options: DocumentParserOptions,
+        questions: List[str]
+) -> str:
+    """Invoke the tool with parsing options, then use agent for analysis."""
+
+    print("🔍 Processing document with signature detection...")
+
+    # Pass parsing options and run the tool
+    parsed_output = await document_markdown_tool.ainvoke({
+        "path": file_path,
+        "options": parsing_options
+    })
+
+    # Build prompt
+    prompt = build_document_analysis_prompt(parsed_output, questions)
+
+    # Run agent on prompt
+    final_state = await app.ainvoke({
+        "messages": [HumanMessage(content=prompt)]
+    })
+
+    return final_state["messages"][-1].content
+
+
+async def example_without_structured_schema():
+    # change to your own document path
+    document_path = "path/to/your/document.pdf"
+    # set the parsing options
+    parsing_options = DocumentParserOptions(
+        detect_signature=True,
+        chunking_strategy=ChunkingStrategy.PAGE,
+        table_output_mode=TableOutputMode.MARKDOWN,
+        skip_ocr=True,
+        timeout_seconds=300
+    )
+
+    analysis_questions = [
+        "Were signatures detected in the document?",
+        "What contextual information can you extract about any signatures?",
+        "Are there any compliance or workflow implications based on signature presence or absence?"
+    ]
+
+    result = await analyze_signatures_agents(
+        file_path=document_path,
+        parsing_options=parsing_options,
+        questions=analysis_questions
+    )
+
+    print("Analysis Result:\n\n", result)
+
+
+async def example_with_stuctured_schema():
+    # change to your own document path
+    document_path = "path/to/your/document.pdf"
+    # the structured schema that you want to set
+    schema_json = """{
+            "properties": {
+                "buyer": {
+                    "properties": {
+                        "buyer_name": {"type": "string"},
+                        "buyer_signature_date": {"type": "string"},
+                        "buyer_signed": {"type": "boolean"}
+                    },
+                    "type": "object"
+                },
+                "seller": {
+                    "properties": {
+                        "seller_name": {"type": "string"},
+                        "seller_signature_date": {"type": "string"},
+                        "seller_signed": {"type": "boolean"}
+                    },
+                    "type": "object"
+                }
+            },
+            "title": "real_estate_purchase_agreement",
+            "type": "object"
+        }"""
+    # set the parsing options
+    parsing_options = DocumentParserOptions(
+        detect_signature=True,
+        page_range="10",  # set the page range here, I am setting it to page 10 here
+        extraction_schema=schema_json,
+        skip_ocr=True,
+        chunking_strategy=ChunkingStrategy.PAGE,
+        table_output_mode=TableOutputMode.MARKDOWN,
+        timeout_seconds=300
+    )
+
+    analysis_questions = "Give me the full parsed result"
+
+    result = await analyze_signatures_agents(
+        file_path=document_path,
+        parsing_options=parsing_options,
+        questions=analysis_questions
+    )
+
+    print("Analysis Result with strctured schema:\n\n", result)
+
+
+if __name__ == "__main__":
+    # example 1
+    asyncio.run(example_without_structured_schema())
+    # example 2
+    asyncio.run(example_with_stuctured_schema())

--- a/src/tensorlake_tool.py
+++ b/src/tensorlake_tool.py
@@ -1,0 +1,219 @@
+import time
+import os
+from dotenv import load_dotenv
+from typing import Optional, Type, Union
+from langchain_core.tools import StructuredTool
+from pydantic import Field, BaseModel, Json
+
+from tensorlake.documentai import DocumentAI, ParsingOptions
+from tensorlake.documentai.parse import (
+    ChunkingStrategy,
+    TableParsingStrategy,
+    TableOutputMode,
+    ExtractionOptions,
+    ModelProvider,
+    FormDetectionMode
+)
+
+load_dotenv()
+
+TENSORLAKE_API_KEY = os.getenv("TENSORLAKE_API_KEY")
+
+
+class DocumentParserOptions(BaseModel):
+    """Comprehensive options for parsing a document with Tensorlake."""
+
+    # Chunking options
+    chunking_strategy: Optional[ChunkingStrategy] = Field(
+        default=ChunkingStrategy.PAGE,
+        description="Strategy for chunking the document (NONE, PAGE, or SECTION_HEADER)"
+    )
+
+    # Table parsing options
+    table_parsing_strategy: TableParsingStrategy = Field(
+        default=TableParsingStrategy.VLM,
+        description="Algorithm for parsing tables (TSR for structured tables, VLM for complex/unstructured tables)"
+    )
+    table_output_mode: TableOutputMode = Field(
+        default=TableOutputMode.MARKDOWN,
+        description="Format for table output (JSON, MARKDOWN, or HTML)"
+    )
+    table_parsing_prompt: Optional[str] = Field(
+        default=None,
+        description="Custom prompt to guide table parsing"
+    )
+    table_summary: bool = Field(
+        default=False,
+        description="Whether to generate summaries of tables"
+    )
+
+    # Figure and image options
+    figure_summary: bool = Field(
+        default=False,
+        description="Whether to generate summaries of figures and images"
+    )
+    figure_summarization_prompt: Optional[str] = Field(
+        default=None,
+        description="Custom prompt for figure summarization"
+    )
+
+    # Page and layout options
+    page_range: Optional[str] = Field(
+        default=None,
+        description="Specific page range to parse (e.g., '1-5' or '1,3,5')"
+    )
+    skew_correction: bool = Field(
+        default=False,
+        description="Whether to apply skew correction to scanned documents"
+    )
+    disable_layout_detection: bool = Field(
+        default=False,
+        description="Whether to disable automatic layout detection"
+    )
+
+    # Signature and form detection
+    detect_signature: bool = Field(
+        default=False,
+        description="Whether to detect the presence of signatures in the document"
+    )
+    form_detection_mode: FormDetectionMode = Field(
+        default=FormDetectionMode.OBJECT_DETECTION,
+        description="Algorithm for form detection (VLM or OBJECT_DETECTION)"
+    )
+
+    # Structured extraction options
+    extraction_schema: Optional[Union[Type[BaseModel], Json]] = Field(
+        default=None,
+        description="JSON schema for structured data extraction"
+    )
+    extraction_prompt: Optional[str] = Field(
+        default=None,
+        description="Custom prompt for structured data extraction"
+    )
+    extraction_model_provider: ModelProvider = Field(
+        default=ModelProvider.TENSORLAKE,
+        description="Model provider for extraction (TENSORLAKE, SONNET, or GPT4OMINI)"
+    )
+    skip_ocr: bool = Field(
+        default=False,
+        description="Whether to skip OCR processing for text-based PDFs"
+    )
+
+    # Webhook options
+    deliver_webhook: bool = Field(
+        default=False,
+        description="Whether to deliver results via webhook when processing is complete"
+    )
+
+    # Processing timeout
+    timeout_seconds: int = Field(
+        default=300,
+        description="Maximum time to wait for processing completion (in seconds)"
+    )
+
+
+def document_to_markdown_converter(path: str, options: DocumentParserOptions) -> str:
+    """
+    Convert a document to markdown using Tensorlake's DocumentAI.
+
+    Args:
+        path: Path to the document file to parse (supports PDF, DOCX, images, etc.)
+        options: DocumentParserOptions object containing all parsing configuration
+
+    Returns:
+        str: The parsed document in markdown format, or error message if failed
+
+    Raises:
+        ValueError: If API key is not configured
+        Exception: If document processing fails
+    """
+    if not TENSORLAKE_API_KEY:
+        return "Error: TENSORLAKE_API_KEY environment variable is not set"
+
+    try:
+        # Initialize DocumentAI client
+        doc_ai = DocumentAI(api_key=TENSORLAKE_API_KEY)
+
+        # Upload document to TensorLake
+        file_id = doc_ai.upload(path=path)
+
+        # Configure parsing options based on user input
+        parsing_options = ParsingOptions(
+            chunking_strategy=options.chunking_strategy,
+            table_parsing_strategy=options.table_parsing_strategy,
+            table_output_mode=options.table_output_mode,
+            table_parsing_prompt=options.table_parsing_prompt,
+            table_summary=options.table_summary,
+            figure_summary=options.figure_summary,
+            figure_summarization_prompt=options.figure_summarization_prompt,
+            page_range=options.page_range,
+            skew_correction=options.skew_correction,
+            disable_layout_detection=options.disable_layout_detection,
+            detect_signature=options.detect_signature,
+            form_detection_mode=options.form_detection_mode,
+            deliver_webhook=options.deliver_webhook
+        )
+
+        # Add extraction options if schema is provided
+        schema = options.extraction_schema
+        if isinstance(schema, dict):
+            import json
+            schema = json.dumps(schema)
+        if schema:
+            parsing_options.extraction_options = ExtractionOptions(
+                schema=schema,
+                prompt=options.extraction_prompt,
+                provider=options.extraction_model_provider,
+                skip_ocr=options.skip_ocr
+            )
+        elif options.skip_ocr:
+            parsing_options.extraction_options = ExtractionOptions(
+                provider=options.extraction_model_provider,
+                skip_ocr=options.skip_ocr
+            )
+
+        # Start parsing job
+        job_id = doc_ai.parse(file_id, options=parsing_options)
+
+        # Poll for completion with configurable timeout
+        start_time = time.time()
+        max_wait_time = options.timeout_seconds
+
+        while time.time() - start_time < max_wait_time:
+            result = doc_ai.get_job(job_id)
+
+            if result.status in ["pending", "processing"]:
+                time.sleep(5)  # Wait 5 seconds before checking again
+            elif result.status == "successful":
+                # Return the parsed content
+                if hasattr(result, 'content') and result.content:
+                    return result.content
+                elif hasattr(result, 'markdown') and result.markdown:
+                    return result.markdown
+                else:
+                    return str(result)  # Fallback to string representation
+            else:
+                return f"Document parsing failed with status: {result.status}"
+
+        # Timeout reached
+        return f"Document processing timeout after {max_wait_time} seconds. Job ID: {job_id}"
+
+    except Exception as e:
+        return f"Error processing document: {str(e)}"
+
+
+async def document_to_markdown_converter_async(path: str, options: DocumentParserOptions) -> str:
+    """Asynchronous version of document to markdown converter."""
+    import asyncio
+    return await asyncio.to_thread(document_to_markdown_converter, path, options)
+
+
+# Create the Document to Markdown tool using StructuredTool
+document_markdown_tool = StructuredTool.from_function(
+    func=document_to_markdown_converter,
+    coroutine=document_to_markdown_converter_async,
+    name="DocumentToMarkdownConverter",
+    description="Convert documents (PDF, DOCX, images, etc.) to markdown using Tensorlake AI. Supports tables, figures, signatures, and structured extraction.",
+    return_direct=False,
+    handle_tool_error="Document parsing failed. Please verify the file path and your Tensorlake API key."
+)


### PR DESCRIPTION
This is the initial integration of Tensorlake with Langchain as a tool for agents.
- Currently the Parsing Options need to be manually passed to the tool
- TODO: Ensure that the Parsing Options are inferred automatically with just the user prompt, say the user passes a document path to the agent and asks it mention the number of signatures that are there, then ParsinOptions should automatically turn `detect_signature=True` and invoke the tool
- TODO: if a document path is already parsed once, ensure questions asked related to that document is answered from parsed data instead of invoking the Tensorlake parser again